### PR TITLE
AGOL Config and TOC fix

### DIFF
--- a/basicviewer/src/modules/core/configuration/app.js
+++ b/basicviewer/src/modules/core/configuration/app.js
@@ -72,6 +72,7 @@ define(["dojo/_base/declare", "dojox/html/entities", "dojo/_base/lang", "dojo/Ev
                     // To hide on startup, set startupwidget to 'none'
                     , displaydetails: true,
                     tablecontents: true,
+                    adddata: true,
                     displayeditor: false,
                     startupwidget: 'displaydetails',
                     ////When editing you need to specify a proxyurl (see below) if the service is on a different domain
@@ -142,7 +143,8 @@ define(["dojo/_base/declare", "dojox/html/entities", "dojo/_base/lang", "dojo/Ev
                     placefinder: {
                         "url": "http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer",
                         "countryCode":""
-                    }
+                    },
+                    displaypointtransp: false
                 };
 
                 this._setDefaults(configOptions);
@@ -189,6 +191,9 @@ define(["dojo/_base/declare", "dojox/html/entities", "dojo/_base/lang", "dojo/Ev
                             }
                             if (response.values.tablecontents != undefined) {
                                 configOptions.tablecontents = response.values.tablecontents;
+                            }
+							if (response.values.adddata != undefined) {
+                                configOptions.adddata = response.values.adddata;
                             }
                             /*if (response.values.displayeditor != undefined) {
                                 configOptions.displayeditor = response.values.displayeditor;
@@ -258,6 +263,9 @@ define(["dojo/_base/declare", "dojox/html/entities", "dojo/_base/lang", "dojo/Ev
                             }
                             if (response.values.customlogolink) {
                                 configOptions.customlogo.link = response.values.customlogolink;
+                            }
+                            if (response.values.displaypointtransp) {
+                                configOptions.displaypointtransp = response.values.displaypointtransp;
                             }
                             /*if (response.values.basemapgrouptitle && response.values.basemapgroupowner) {
                                 configOptions.basemapgroup.title = response.values.basemapgrouptitle;

--- a/basicviewer/src/modules/core/configuration/config.js
+++ b/basicviewer/src/modules/core/configuration/config.js
@@ -9,6 +9,7 @@
     "values": {
         "displaybasemaps": true,
             "tablecontents": true,
+            "adddata": true,
             "displayshare": false,
             "displaymeasure": false,
             "displaylocation": true,
@@ -24,6 +25,7 @@
             "displaysearch": true,
             "displaydraw": false,
             "embed": false
+            "displaypointtransp": false
     },
     "configurationSettings": [{
         "category": "<b>Layout</b>",
@@ -127,6 +129,11 @@
             "fieldName": "embed",
             "type": "boolean",
             "tooltip": ""
+        },{
+            "label": "Show Transparency Slider for Point/Line layers",
+            "fieldName": "displaypointtransp",
+            "type": "boolean",
+            "tooltip": ""
         }]
     }, {
         "category": "<b>Widgets</b>",
@@ -139,7 +146,12 @@
             "label": "Table of Contents",
             "fieldName": "tablecontents",
             "type": "boolean",
-            "tooltip": "Legend and Add Data"
+            "tooltip": "Legend"
+        },{
+            "label": "Add Data",
+            "fieldName": "adddata",
+            "type": "boolean",
+            "tooltip": "Add Data"
         }, {
             "label": "Startup Widget:",
             "fieldName": "startupwidget",
@@ -150,6 +162,9 @@
             }, {
                 "label": "Table of Contents",
                 "value": "tablecontents"
+            }, {
+                "label": "Add Data",
+                "value": "adddata"
             }, {
                 "label": "None",
                 "value": "none"

--- a/basicviewer/src/modules/core/toc/legend/TOC.js
+++ b/basicviewer/src/modules/core/toc/legend/TOC.js
@@ -3,72 +3,74 @@
  * connector (dojo/aspect) does not obtain the proper callback parameters.
  */
 define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_base/lang", "./_RootLayerTOC"
-    , "dojo/on", "dojo/_base/connect", "dojo/Evented", "xstyle/css!./css/TOC.css" ],
-    function(declare, domConstruct, WidgetBase, lang, _RootLayerTOC, on, connect) {
+    , "dojo/on", "dojo/_base/connect", "dojo/Evented", "xstyle/css!./css/TOC.css"],
+    function (declare, domConstruct, WidgetBase, lang, _RootLayerTOC, on, connect) {
         return declare([WidgetBase], {
-        	indentSize: 18,
-	        swatchSize: [30, 30],
-	        refreshDelay: 500,
-	        style: 'inline',
+            indentSize: 18,
+            swatchSize: [30, 30],
+            refreshDelay: 500,
+            style: 'inline',
             /*This is the master list of layers in the map to show in the tree
-                {   layer: <the actual layer object>,
-                    title: <the label in the tree>,
-                    toc: <this TOC.js>  }
-                */
+            {   layer: <the actual layer object>,
+            title: <the label in the tree>,
+            toc: <this TOC.js>  }
+            */
             _rootLayerTOCs: null,
             //All layers and sub-layers in the tree have a layerinfo
-	        layerInfos: null,
-	        slider: false,
+            layerInfos: null,
+            slider: false,
             //The map object
             map: null,
             //The map configuration JSON object. Used to determine how to display layers in the TOC.
             webMap: null,
 
-	        /**
-	         * @name TOCLayerInfo
-	         * @class This is an object literal that specify the options for each map rootLayer layer.
-	         * @property {esri.layers.ArcGISTiledMapServiceLayer | esri.layers.ArcGISDynamicMapServiceLayer} rootLayer: ArcGIS Server layer.
-	         * @property {string} [title] title. optional. If not specified, rootLayer name is used.
-	         * @property {Boolean} [slider] whether to show slider for each rootLayer to adjust transparency. default is false.
-	         * @property {Boolean} [noLegend] whether to skip the legend, and only display layers. default is false.
-	         * @property {Boolean} [collapsed] whether to collapsed the rootLayer layer at beginning. default is false, which means expand if visible, collapse if not.
-	         *
-	         */
-	        /**
-	         * @name TOCOptions
-	         * @class This is an object literal that specify the option to construct a {@link TOC}.
-	         * @property {esri.Map} [map] the map instance. required.
-	         * @property {Object[]} [layerInfos] a subset of layers in the map to show in TOC. each object is a {@link TOCLayerInfo}
-	         * @property {Number} [indentSize] indent size of tree nodes. default to 18.
-	         */
-	        /**
-	         * Create a Table Of Contents (TOC)
-	         * @name TOC
-	         * @constructor
-	         * @class This class is a Table Of Content widget.
-	         * @param {ags.TOCOptions} opts
-	         * @param {DOMNode|id} srcNodeRef
-	         */
-	        constructor: function(params, srcNodeRef) {
-	            params = params || {};
-	            if (!params.map) {
-	                throw new Error('no map defined in params for TOC');
-	            }
-	            dojo.mixin(this, params);
-	        },
-	        // extension point
-	        postCreate: function() {
+            displayPointT: true,
+
+            /**
+            * @name TOCLayerInfo
+            * @class This is an object literal that specify the options for each map rootLayer layer.
+            * @property {esri.layers.ArcGISTiledMapServiceLayer | esri.layers.ArcGISDynamicMapServiceLayer} rootLayer: ArcGIS Server layer.
+            * @property {string} [title] title. optional. If not specified, rootLayer name is used.
+            * @property {Boolean} [slider] whether to show slider for each rootLayer to adjust transparency. default is false.
+            * @property {Boolean} [noLegend] whether to skip the legend, and only display layers. default is false.
+            * @property {Boolean} [collapsed] whether to collapsed the rootLayer layer at beginning. default is false, which means expand if visible, collapse if not.
+            *
+            */
+            /**
+            * @name TOCOptions
+            * @class This is an object literal that specify the option to construct a {@link TOC}.
+            * @property {esri.Map} [map] the map instance. required.
+            * @property {Object[]} [layerInfos] a subset of layers in the map to show in TOC. each object is a {@link TOCLayerInfo}
+            * @property {Number} [indentSize] indent size of tree nodes. default to 18.
+            */
+            /**
+            * Create a Table Of Contents (TOC)
+            * @name TOC
+            * @constructor
+            * @class This class is a Table Of Content widget.
+            * @param {ags.TOCOptions} opts
+            * @param {DOMNode|id} srcNodeRef
+            */
+            constructor: function (params, srcNodeRef) {
+                params = params || {};
+                if (!params.map) {
+                    throw new Error('no map defined in params for TOC');
+                }
+                dojo.mixin(this, params);
+            },
+            // extension point
+            postCreate: function () {
                 this._rootLayerTOCs = [];
                 /*The TOC could be instantiated during different stages in the app
-                 1. During startup: in which case some layers might have been added to map, but maybe not all
-                 2. After startup: prompted by user to display, in which case probably all layers have been added.
-                 In either case, need to handle the later addition, removal, and reorder of layers that occur outside of the toc dijit
-                 */
+                1. During startup: in which case some layers might have been added to map, but maybe not all
+                2. After startup: prompted by user to display, in which case probably all layers have been added.
+                In either case, need to handle the later addition, removal, and reorder of layers that occur outside of the toc dijit
+                */
                 //Hook up the map's layer added and removed events right away to capture any changes to the map
                 connect.connect(this.map, "onLayerAddResult", lang.hitch(this, function (layer, error) {
                     /* If the layer has a title property, which would be set by another module, or if id corresponds to an operationalLayer in web map, then add to TOC.
-                     Otherwise, disregard, as layers get added/removed more often than might think (e.g. KML's layers, featurelayers for popups on map services, basemaps).
-                     When popups are configured on a map service's layer(s) it also adds a feature layer(s) to use for the popup, don't show these.*/
+                    Otherwise, disregard, as layers get added/removed more often than might think (e.g. KML's layers, featurelayers for popups on map services, basemaps).
+                    When popups are configured on a map service's layer(s) it also adds a feature layer(s) to use for the popup, don't show these.*/
                     if (error)
                         return;
                     this._handleLayerForToc(layer);
@@ -80,7 +82,7 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
                         var rootLayerToc = this._rootLayerTOCs[i];
                         if (layer.id === rootLayerToc.rootLayer.id) {
                             domConstruct.destroy(rootLayerToc.domNode.id);
-                            this._rootLayerTOCs.splice(i,1);
+                            this._rootLayerTOCs.splice(i, 1);
                             break;
                         }
                     }
@@ -90,11 +92,11 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
                 if (!this.layerInfos) {
                     this.layerInfos = [];
                     /* Loop through the graphics layers of the map (feature layers, graphics, kml).
-                     Note: When a popup is configured on a map service's layer(s) it also creates a FeatureLayer for each applicable layer.
-                     The id of the featurelayer is: <service layer id>_<feature layer id (order in map)>
-                     Do not show these featurelayer's in legend.
-                     Note 2: Graphics layers are always on top of the service layers, regardless of web map configuration
-                     */
+                    Note: When a popup is configured on a map service's layer(s) it also creates a FeatureLayer for each applicable layer.
+                    The id of the featurelayer is: <service layer id>_<feature layer id (order in map)>
+                    Do not show these featurelayer's in legend.
+                    Note 2: Graphics layers are always on top of the service layers, regardless of web map configuration
+                    */
                     for (var r = this.map.graphicsLayerIds.length - 1; r >= 0; r--) {
                         var rootGraphicLayer = this.map.getLayer(this.map.graphicsLayerIds[r]);
                         this._handleLayerForToc(rootGraphicLayer);
@@ -110,13 +112,13 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
                 if (!this._zoomHandler) {
                     this._zoomHandler = dojo.connect(this.map, "onZoomEnd", this, "_adjustToState");
                 }
-	        }
+            }
 
             // The handler that checks if a map layer should be included in TOC. If so, handles inserting and updating _rootLayerTOCs list
             , _handleLayerForToc: function (layer) {
                 /* If the layer has a title property, which would be set by another module, or if id corresponds to an operationalLayer in web map, then add to TOC.
-                 Otherwise, disregard, as layers get added/removed more often than might think (e.g. KML's layers, featurelayers for popups on map services, basemaps).
-                 When popups are configured on a map service's layer(s) it also adds a feature layer(s) to use for the popup, don't show these.*/
+                Otherwise, disregard, as layers get added/removed more often than might think (e.g. KML's layers, featurelayers for popups on map services, basemaps).
+                When popups are configured on a map service's layer(s) it also adds a feature layer(s) to use for the popup, don't show these.*/
                 var createTocNode = false;
                 var nodeTitle = null;
                 if (layer.title) {
@@ -137,40 +139,44 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
                     }
                 }
                 if (createTocNode) {
+                    var sliderTF = false;
+                    if (this.displayPointT || (!(this.displayPointT) && !(layer.geometryType == "esriGeometryPoint" || layer.geometryType == "esriGeometryPolyline"))) {
+                        sliderTF = true;
+                    }
                     this._insertRootLayer({
                         layer: layer,
                         title: nodeTitle,
                         noLegend: !this._shouldShowLegend(layer),
-                        slider: true
+                        slider: sliderTF
                     });
                 }
             }
 
             , _insertRootLayer: function (layerInfo) {
-                    //create the TOC item for a main layer
-                    var rootLayer = layerInfo.layer;
-                    var svcTOC = new _RootLayerTOC({
-                        rootLayer: rootLayer,
-                        info: layerInfo,
-                        toc: this
-                    });
-                    //Now find the corresponding next node in the TOC
-                    var nextLayer = this.FindNextTocNode(rootLayer, false);
-                    //Add to the list of TOC nodes
-                    if (nextLayer.nextIndexInToc != null && nextLayer.nextIndexInToc >= 0) {
-                        this._rootLayerTOCs.splice(nextLayer.nextIndexInToc, 0, svcTOC);
-                    } else
-                        this._rootLayerTOCs.push(svcTOC);
-                    //Insert the actual dom node into window
-                    if (nextLayer.nextTocNode)
-                        domConstruct.place(svcTOC.domNode, nextLayer.nextTocNode.domNode, 'before');
-                    else
-                        domConstruct.place(svcTOC.domNode, this.domNode);
+                //create the TOC item for a main layer
+                var rootLayer = layerInfo.layer;
+                var svcTOC = new _RootLayerTOC({
+                    rootLayer: rootLayer,
+                    info: layerInfo,
+                    toc: this
+                });
+                //Now find the corresponding next node in the TOC
+                var nextLayer = this.FindNextTocNode(rootLayer, false);
+                //Add to the list of TOC nodes
+                if (nextLayer.nextIndexInToc != null && nextLayer.nextIndexInToc >= 0) {
+                    this._rootLayerTOCs.splice(nextLayer.nextIndexInToc, 0, svcTOC);
+                } else
+                    this._rootLayerTOCs.push(svcTOC);
+                //Insert the actual dom node into window
+                if (nextLayer.nextTocNode)
+                    domConstruct.place(svcTOC.domNode, nextLayer.nextTocNode.domNode, 'before');
+                else
+                    domConstruct.place(svcTOC.domNode, this.domNode);
             }
 
             /*Find the next (lower in the overlay order) layer in the map that is present in the TOC
-                Return object has form: { nextTocNode: <TOC Node>, nextIndexInMap: <index in map layer list>, nextIndexInToc: <index in toc list>
-                                            , mapOrGraphics: <whether next layer found in graphics or layers list> }*/
+            Return object has form: { nextTocNode: <TOC Node>, nextIndexInMap: <index in map layer list>, nextIndexInToc: <index in toc list>
+            , mapOrGraphics: <whether next layer found in graphics or layers list> }*/
             , FindNextTocNode: function (rootLayer, restrictToGraphicsLyrs) {
                 //Loop through the map's graphics layers, then the service layers to determine the appropriate location to insert this TOCNode
                 var nextTocNode = null;
@@ -278,20 +284,20 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
             , MoveRootNodeDown: function (refNode, newIndex) {
                 var nodeToMove = this._rootLayerTOCs[newIndex - 1];
                 domConstruct.place(nodeToMove.domNode, refNode.domNode, 'after');
-                this._rootLayerTOCs.splice(newIndex-1,1);
-                this._rootLayerTOCs.splice(newIndex,0,nodeToMove);
+                this._rootLayerTOCs.splice(newIndex - 1, 1);
+                this._rootLayerTOCs.splice(newIndex, 0, nodeToMove);
             }
             //Moves the node in the TOC up one position. Does not reorder actual map layers.
             , MoveRootNodeUp: function (refNode, newIndex) {
                 var nodeToMove = this._rootLayerTOCs[newIndex + 1];
                 domConstruct.place(nodeToMove.domNode, refNode.domNode, 'before');
-                this._rootLayerTOCs.splice(newIndex+1,1);
-                this._rootLayerTOCs.splice(newIndex,0,nodeToMove);
+                this._rootLayerTOCs.splice(newIndex + 1, 1);
+                this._rootLayerTOCs.splice(newIndex, 0, nodeToMove);
             }
 
             /* Determine if the layer type is appropriate for showing sub-layers with legend entries.
-                Basically just AGS map services at this point. Also, honor web map settings for Hide in Legend */
-            , _shouldShowLegend: function(layer) {
+            Basically just AGS map services at this point. Also, honor web map settings for Hide in Legend */
+            , _shouldShowLegend: function (layer) {
                 if (!(layer instanceof (esri.layers.ArcGISDynamicMapServiceLayer) || layer instanceof (esri.layers.ArcGISTiledMapServiceLayer)))
                     return false;
                 for (var p = this.webMap.itemData.operationalLayers.length - 1; p >= 0; p--) {
@@ -308,14 +314,14 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/_
             }
 
             //This appears to mainly function for scale-dependent rendering of the toc items
-	        , _adjustToState: function() {
-	            dojo.forEach(this._rootLayerTOCs, function(widget) {
+	        , _adjustToState: function () {
+	            dojo.forEach(this._rootLayerTOCs, function (widget) {
 	                widget._adjustToState();
 	            });
 	        }
-	        , destroy: function() {
+	        , destroy: function () {
 	            dojo.disconnect(this._zoomHandler);
 	            this._zoomHandler = null;
 	        }
+        });
     });
-});

--- a/basicviewer/src/modules/core/toc/legend/_TOCNode.js
+++ b/basicviewer/src/modules/core/toc/legend/_TOCNode.js
@@ -200,6 +200,21 @@ define(["dojo/_base/declare", "dijit/_WidgetBase", "dijit/_TemplatedMixin", "dij
 	                                value: "*"
 	                            }].concat(rends);
 	                        }
+							//the array of legend items might have duplicates, remove these by matching by url (not sure what URL this is, but seems to be unique per symbol)
+							var tempArray = new Array();
+							tempArray[0] = rends[0];
+							for (var i = 0; i < rends.length; i++) {
+								var flag = true;
+								for (var j = 0; j < tempArray.length; j++) {
+									if (tempArray[j].url == rends[i].url) {
+										flag = false;
+									}
+								} //for loop
+								if (flag == true)
+									tempArray.push(rends[i]);
+							} //for loop
+							rends = tempArray;								
+							
 	                        this._createChildrenNodes(rends, 'legend');
 	                    }
 	                } else if (layer.legends && !this.rootLayerTOC.info.noLegend) {

--- a/basicviewer/src/modules/core/toc/toc.js
+++ b/basicviewer/src/modules/core/toc/toc.js
@@ -12,6 +12,8 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/o
             //*** The ESRI Web Map object to be used by the TOC to set properties such as title, visiblity, etc.
             webMap: null,
 
+            appConfig: null,
+
             // The table of contents dijit
             _dijitToc: null,
             _addDataPane: null,
@@ -178,6 +180,7 @@ define(["dojo/_base/declare", "dojo/dom-construct", "dijit/_WidgetBase", "dojo/o
                     this._dijitToc.destroyRecursive();this._dijitToc = new legendToc({
                         map: this.esriMap
                         , webMap: this.webMap
+                        , displayPointT: this.appConfig.displaypointtransp
                 });
             }
         });

--- a/basicviewer/src/modules/core/utilities/tabmanager.js
+++ b/basicviewer/src/modules/core/utilities/tabmanager.js
@@ -67,9 +67,9 @@ define(["dojo/_base/declare", "../utilities/environment", "dojo/_base/lang", "do
                 }
 
                 //*** Table of Contents- use as an example of lazy-loading a pane at runtime
-                if ((this._AppConfig.tablecontents === 'true' || this._AppConfig.tablecontents == true)) {
+                if ((this._AppConfig.adddata === 'true' || this._AppConfig.adddata == true)) {
                     //*** Check if this pane was set to be the startup pane in app.js or AGO. Replace the param name in next line.
-                    var configParamName = 'tablecontents';
+                    var configParamName = 'adddata';
                     //*** Constructor params for the tab (which is a contentpane- http://dojotoolkit.org/reference-guide/1.8/dijit/layout/ContentPane.html).
                     //*** Give the tab's content pane a unique id.
                     //*** and title to display in the tab


### PR DESCRIPTION
Ability to turn on/off transparency slider for features other than
polygon.   Sets this way by default, but can be configured to turn back
on.

TOC fix to reduce redundant symbology of items that have different
values but the same symbol.
